### PR TITLE
Update button's type and add correct form submission handler

### DIFF
--- a/src/js/components/KeptTodoForm.js
+++ b/src/js/components/KeptTodoForm.js
@@ -69,7 +69,7 @@ var KeptTodoForm = React.createClass({
     console.log("---");
     return (
       <Modal title="Create new Todo" onRequestHide={this.props.resetForm} animation={false}>
-        <form className="todo-form" role="form" onSubmit={this.handleSubmit}>
+        <form className="todo-form" role="form" onSubmit={this.addTask}>
           <div className="modal-body">
             <input type="hidden" ref="id" defaultValue={this.props.data.id} />
             <div className="form-group">
@@ -82,9 +82,9 @@ var KeptTodoForm = React.createClass({
             }</ul>
           </div>
           <div className="modal-footer form-group">
-            <button className="btn btn-default" onClick={this.addTask}>Add task</button>
+            <button className="btn btn-default" type="submit">Add task</button>
             &nbsp;
-            <button className="btn btn-primary" type="submit">Save</button>
+            <button className="btn btn-primary" type="button" onClick={this.handleSubmit}>Save</button>
             &nbsp;
             <a href="#" onClick={this.handleCancel}>Cancel</a>
           </div>


### PR DESCRIPTION
The default type value for a button is submit so there 2 submit button.
The weird thing is, when you push enter to validate the form, it should call onSubmit handler but since the first submit button has an onclick handler, its handler take precedence on onSubmit handler.
If you switch button's dom order, addTask will not be called.

These PR remove implicit behavior.
